### PR TITLE
Fix use of deprecated CoreText constant

### DIFF
--- a/src/fonttest/coretext_font.mm
+++ b/src/fonttest/coretext_font.mm
@@ -182,7 +182,7 @@ void CoreTextFont::GetGlyphOutline(int glyphID, const FontVariation& variation,
   CGGlyph glyphs[1];
   glyphs[0] = static_cast<CGGlyph>(glyphID);
   CGSize advances[1];
-  CTFontGetAdvancesForGlyphs(font, kCTFontHorizontalOrientation, glyphs,
+  CTFontGetAdvancesForGlyphs(font, kCTFontOrientationHorizontal, glyphs,
                              advances, 1);
   char buffer[200];
   snprintf(buffer, sizeof(buffer), "%ld %ld %ld %ld",


### PR DESCRIPTION
[kCTFontHorizontalOrientation](https://developer.apple.com/reference/coretext/ctfontorientation/1509711-kctfonthorizontalorientation) is deprecated, and replaced with [kCTFontOrientationHorizontal](https://developer.apple.com/reference/coretext/ctfontorientation/kctfontorientationhorizontal). Causes compilation error on 10.11 for me.